### PR TITLE
analysis: Add sched-related event catching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 all:
 	make -C src
 

--- a/analysis/01-one-sched-other-one-second/01-one-sched-other-one-second.sh
+++ b/analysis/01-one-sched-other-one-second/01-one-sched-other-one-second.sh
@@ -11,11 +11,15 @@
 # just an simple example to get things done.
 cd $(dirname $0)
 sh ../configure-cpu-set.sh
-../../src/runner -i 1000000 -I 0 -s 100 -r 100 -d 200 -p 1000 &
+../../src/runner -I 0 --period 2000 --runtime 150 --deadline 500 --calctime 100 --sleeptime 2000 & 
 PID1=$!
 
-perf record -p $PID1 &
+EVENTS='{raw_syscalls:*,sched:sched_switch,sched:sched_migrate_task,'
+'sched:sched_process_exec,sched:sched_process_fork,sched:sched_process_exit,'
+'sched:sched_stat_runtime,sched:sched_stat_wait,sched:sched_stat_sleep,'
+'sched:sched_stat_blocked,sched:sched_stat_iowait}'
 
-sleep 1
+perf sched record -p $PID1 -e $EVENTS &
 
+sleep 60
 kill -9 $PID1

--- a/analysis/01-one-sched-other-one-second/Makefile
+++ b/analysis/01-one-sched-other-one-second/Makefile
@@ -1,5 +1,5 @@
 all:
-	sudo /bin/sh 01-one-sched-other-one-second.sh
+	/bin/sh 01-one-sched-other-one-second.sh
 
 clean:
 	-rm -rf perf.data perf.data.old

--- a/analysis/02-3-deadline-tasks/02-3-deadline-tasks.sh
+++ b/analysis/02-3-deadline-tasks/02-3-deadline-tasks.sh
@@ -6,24 +6,24 @@
 cd $(dirname $0)
 sh ../configure-cpu-set.sh
 
-cpu_iter=1000000
 
-./src/runner -i cpu_iter -I 0 -s 200 -r 100 -d 150 -p 1000  &
+perf sched record ../../src/runner -I 0 --period 2000 --runtime 150 --deadline 500 --calctime 100 --sleeptime 2000 & 
 PID1=$!
+echo $PID1
 
-./src/runner -i cpu_iter -I 0 -s 200 -r 100 -d 150 -p 1000  &
+../../src/runner -I 0 --period 2000 --runtime 150 --deadline 500 --calctime 100 --sleeptime 2000 & 
 PID2=$!
 
-./src/runner -i cpu_iter -I 0 -s 200 -r 100 -d 150 -p 1000  &
+../../src/runner -I 0 --period 2000 --runtime 150 --deadline 500 --calctime 100 --sleeptime 2000 & 
 PID3=$!
 
 # sched other
-./src/runner -i 1000000000000 -I 0 -s 200 -r 0 -d 0 -p 0  &
+../../src/runner -I 0 --cpu-iterations 1000000000000 --sleeptime 0 & 
 PID4=$!
 
 
 # execute test for N seconds
-sleep 120
+sleep 60
 
 # kill everything
 kill -9 $PID1

--- a/src/runner.c
+++ b/src/runner.c
@@ -23,10 +23,11 @@
 #define S_TO_US_FACTOR (1ULL * 1000 * 1000)
 
 #define CALC_TIME_US (1ULL * 100 * 1000)
-#define CPU_TICK_REG (10ULL * 1000 * 1000)
 
 #define DEFAULT_SLEEPTIME 1000
 #define DEFAULT_CALCTIME 100
+
+#define OAKING_LOOPS 10
 
 /* XXX use the proper syscall numbers */
 #ifdef __x86_64__
@@ -128,12 +129,8 @@ void parse_args(struct config *cfg, int argc, char **argv)
 	   {NULL, no_argument, NULL, 0}
 	};
 
-	for (;;) {
-		opt = getopt_long(argc, argv, "c:i:I:s:r:p:d:h",
-				long_options, &option_index);
-		if (opt == -1)
-			break;
-
+	while ((opt = getopt_long(argc, argv, "c:i:I:s:r:p:d:h",
+				long_options, &option_index)) != -1) {
 		switch (opt) {
 		case CPU_ITERATIONS:
 		case 'i':
@@ -256,7 +253,7 @@ void oak_cpu(struct config *cfg)
 	long long reg = 0, integ = 0;
 
 	puts("entering oak loop");
-	for (i = 0; i < 10; i++) {
+	for (i = 0; i < OAKING_LOOPS; i++) {
 		calctime_now = 0, reg = 0, integ = 0;
 
 		do {
@@ -272,7 +269,7 @@ void oak_cpu(struct config *cfg)
 		averaging += integ;
 	}
 
-	cfg->cpu_iterations = averaging / 100;
+	cfg->cpu_iterations = averaging / OAKING_LOOPS;
 	printf("Set CPU-iterations to %llu.\n", cfg->cpu_iterations);
 	puts("Leaving oak.");
 }

--- a/src/runner.c
+++ b/src/runner.c
@@ -244,6 +244,11 @@ static inline bool five_perct_exact(unsigned now, unsigned goal)
 }
 
 
+/*
+ * Calculates a number for the cpu to decrement so the time needed to reach 0
+ * equals roughly the configured time calc_time_us.
+ * This functions implements a PD regulator.
+ */
 void oak_cpu(struct config *cfg)
 {
 	long long calctime_now = 0, calctime_goal = cfg->calc_time_us;

--- a/src/runner.c
+++ b/src/runner.c
@@ -247,7 +247,7 @@ static inline bool five_perct_exact(unsigned now, unsigned goal)
 /*
  * Calculates a number for the cpu to decrement so the time needed to reach 0
  * equals roughly the configured time calc_time_us.
- * This functions implements a PD regulator.
+ * This functions implements a PI regulator.
  */
 void oak_cpu(struct config *cfg)
 {
@@ -322,7 +322,6 @@ int main(int argc, char *argv[])
 	};
 
 	parse_args(&cfg, argc, argv);
-
 	oak_cpu(&cfg);
 
 	if (cfg.attr.sched_runtime > 0 && cfg.attr.sched_period > 0 &&

--- a/src/runner.c
+++ b/src/runner.c
@@ -22,9 +22,11 @@
 #define MS_TO_US_FACTOR (1ULL * 1000)
 #define S_TO_US_FACTOR (1ULL * 1000 * 1000)
 
-#define ROUGHLY_EQUAL(x, y) (x < y + 1000 && x > y - 1000)
 #define CALC_TIME_US (1ULL * 100 * 1000)
 #define CPU_TICK_REG (10ULL * 1000 * 1000)
+
+#define DEFAULT_SLEEPTIME 1000
+#define DEFAULT_CALCTIME 100
 
 /* XXX use the proper syscall numbers */
 #ifdef __x86_64__
@@ -71,7 +73,7 @@ struct config {
 
 int sched_setattr(pid_t pid, const struct sched_attr *attr, unsigned int flags)
 {
-	printf("Periode: %llu, Runtime: %llu, Deadline: %llu\n",
+	printf("Set: Period: %llu us, Runtime: %llu us, Deadline: %llu\n us",
 			attr->sched_period, attr->sched_runtime, attr->sched_deadline);
 
 	return syscall(__NR_sched_setattr, pid, attr, flags);
@@ -126,8 +128,12 @@ void parse_args(struct config *cfg, int argc, char **argv)
 	   {NULL, no_argument, NULL, 0}
 	};
 
-	opt = getopt_long(argc, argv, "c:i:I:s:r:p:d:h", long_options, &option_index);
-	while (opt != -1) {
+	for (;;) {
+		opt = getopt_long(argc, argv, "c:i:I:s:r:p:d:h",
+				long_options, &option_index);
+		if (opt == -1)
+			break;
+
 		switch (opt) {
 		case CPU_ITERATIONS:
 		case 'i':
@@ -170,8 +176,6 @@ void parse_args(struct config *cfg, int argc, char **argv)
 			exit(EXIT_FAILURE);
 			break;
 		}
-
-		opt = getopt_long(argc, argv, "i:I:s:r:p:d:", long_options, &option_index);
 	}
 }
 
@@ -219,41 +223,58 @@ unsigned us_timediff(struct timeval tv_start, struct timeval tv_end)
 }
 
 
-unsigned busy_cycles(struct config *cfg)
+unsigned busy_cycles(unsigned long long iterations)
 {
-	unsigned long long i = cfg->cpu_iterations;
 	struct timeval tv_start, tv_end;
 
 	gettimeofday(&tv_start, NULL);
 
-	while (i--);
+	puts("start decrementing.");
+	while (iterations--);
+	puts("done decrementing.");
 
 	gettimeofday(&tv_end, NULL);
 	return us_timediff(tv_start, tv_end);
 }
 
 
-void oak_iterations(struct config *cfg)
+static inline bool five_perct_exact(unsigned now, unsigned goal)
 {
-	unsigned i, runtime;
-	unsigned long long averaging = 0;
+	if ((now > goal * 0.95) && (now < goal * 1.05))
+		return true;
+	else
+		return false;
+}
 
-	printf("Normalizing cpu-iterations to fit %llu ms.\n",
-			cfg->calc_time_us / 1000);
-	for (i = 0; i < 100; i++) {
-		runtime = busy_cycles(cfg);
-		while (!(runtime > cfg->calc_time_us - 10000 &&
-					runtime < cfg->calc_time_us + 10000)) {
-			cfg->cpu_iterations += CPU_TICK_REG;
-			runtime = busy_cycles(cfg);
-			printf("Runtime: %u ms\n", runtime / 1000);
-		}
-		averaging += cfg->cpu_iterations;
+
+void oak_cpu(struct config *cfg)
+{
+	long long calctime_now = 0, calctime_goal = cfg->calc_time_us;
+	unsigned kp = 5;
+	unsigned long long averaging = 0;
+	int i;
+	long long reg = 0, integ = 0;
+
+	puts("entering oak loop");
+	for (i = 0; i < 10; i++) {
+		calctime_now = 0, reg = 0, integ = 0;
+
+		do {
+			reg = calctime_goal - calctime_now;
+			reg *= kp;
+			integ += reg;
+			printf("Iterations now: %lli\n", integ);
+			calctime_now = busy_cycles(integ);
+			printf("Calctime now: %llu, goal: %llu\n", calctime_now, calctime_goal);
+		} while (!five_perct_exact(calctime_now, calctime_goal));
+		printf("Calctime now: %llu, goal: %llu\n", calctime_now, calctime_goal);
+
+		averaging += integ;
 	}
 
-	averaging /= 100;
-	cfg->cpu_iterations = averaging;
-	puts("leaving oak");
+	cfg->cpu_iterations = averaging / 100;
+	printf("Set CPU-iterations to %llu.\n", cfg->cpu_iterations);
+	puts("Leaving oak.");
 }
 
 
@@ -265,8 +286,7 @@ void xsleep(struct config *cfg)
 	struct timeval tv_start, tv_end;
 	gettimeofday(&tv_start, NULL);
 
-	/* printf("Sleeping %u us...\n", cfg->sleeptime_ms); */
-	usleep(cfg->sleeptime_ms * 1000);
+	usleep(cfg->sleeptime_ms * MS_TO_US_FACTOR);
 
 	gettimeofday(&tv_end, NULL);
 
@@ -295,18 +315,13 @@ int main(int argc, char *argv[])
 		.attr = attr,
 		.cpu_iterations = 1 * 1000 * 1000,
 		.program_iterations = 1,
-		.sleeptime_ms = 1000,
-		.calc_time_us = 1000 * MS_TO_US_FACTOR,
+		.sleeptime_ms = DEFAULT_SLEEPTIME,
+		.calc_time_us = DEFAULT_CALCTIME * MS_TO_US_FACTOR,
 	};
 
 	parse_args(&cfg, argc, argv);
 
-	/* A sleeptime equal 0 indicates that the user wants to create a high
-	 * workload with big number of cpu-iterations.
-	 * In this case, do not oak. */
-	if (cfg.sleeptime_ms > 0) {
-		oak_iterations(&cfg);
-	}
+	oak_cpu(&cfg);
 
 	if (cfg.attr.sched_runtime > 0 && cfg.attr.sched_period > 0 &&
 			cfg.attr.sched_deadline > 0) {
@@ -314,7 +329,7 @@ int main(int argc, char *argv[])
 	}
 
 	for (i = 0; run; i++) {
-		printf("Calculated for %u us.\n", busy_cycles(&cfg));
+		printf("Calculated for %u us.\n", busy_cycles(cfg.cpu_iterations));
 		xsleep(&cfg);
 
 		/* run forever if program_iterations is set to 0 */

--- a/src/runner.c
+++ b/src/runner.c
@@ -24,7 +24,7 @@
 
 #define ROUGHLY_EQUAL(x, y) (x < y + 1000 && x > y - 1000)
 #define CALC_TIME_US (1ULL * 100 * 1000)
-#define CPU_TICK_REG (1ULL * 1000 * 1000)
+#define CPU_TICK_REG (10ULL * 1000 * 1000)
 
 /* XXX use the proper syscall numbers */
 #ifdef __x86_64__
@@ -246,13 +246,14 @@ void oak_iterations(struct config *cfg)
 					runtime < cfg->calc_time_us + 10000)) {
 			cfg->cpu_iterations += CPU_TICK_REG;
 			runtime = busy_cycles(cfg);
-			printf("%u\n", runtime);
+			printf("Runtime: %u ms\n", runtime / 1000);
 		}
 		averaging += cfg->cpu_iterations;
 	}
 
 	averaging /= 100;
 	cfg->cpu_iterations = averaging;
+	puts("leaving oak");
 }
 
 


### PR DESCRIPTION
scheduler event tracing for `perf record -e` as we discussed. Ugly, but works. For now.

I'd say we implement it for now, see if everything works for the 4 process variant and then optimize from there.

Additionally I implemented a better regulation mechanism for the CPU iterations. I still have to optimize this, but it should work far more reliable and better than the old method, because it follows scientific regulator design.