### PR TITLE
Philipp/analyze deadline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 src/runner
+*.pid
+*.log
+analysis/*/results/*
 
 # perf data
 perf.data

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ all:
 analyze: all
 	make -C analysis/01-one-sched-other-one-second/
 
+analyze-deadline: all
+	make -C analysis/02-3-deadline-tasks
+
 clean:
 	make -C src clean
 	make -C analysis/01-one-sched-other-one-second/ clean

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 all:
 	make -C src
 
+debug:
+	make debug -C src
+
 analyze: all
 	make -C analysis/01-one-sched-other-one-second/
 

--- a/analysis/01-one-sched-other-one-second/Makefile
+++ b/analysis/01-one-sched-other-one-second/Makefile
@@ -5,4 +5,4 @@ rerun:
 	/bin/sh 01-one-sched-other-one-second-rerun.sh
 
 clean:
-	rm -f perf.data perf.data.old ./results/results.txt
+	rm -f perf.data perf.data.old ./results/*

--- a/analysis/02-3-deadline-tasks/02-3-deadline-tasks.sh
+++ b/analysis/02-3-deadline-tasks/02-3-deadline-tasks.sh
@@ -7,35 +7,37 @@ cd $(dirname $0)
 sh ./configure-cpu-set.sh
 echo $$ > /dev/cpuset/cpu0/tasks
 
-../../src/runner -I 0 -o 10 --period 1000 --runtime 100 --deadline 900 --calctime 100 --sleeptime 1900 &
+../../src/runner -I 0 -o 5 --period 1000 --runtime 100 --deadline 200 --cpu-iterations 100000000000 --sleeptime 0 &
 PID1=$!
+echo $PID1 > ./deadlinerunner1.pid
 
-../../src/runner -I 0 -o 10 --period 1000 --runtime 150 --deadline 500 --calctime 100 --sleeptime 1900 &
+../../src/runner -I 0 -o 0 --period 1000 --runtime 100 --deadline 200 --sleeptime 0 &
 PID2=$!
+echo $PID2 > ./deadlinerunner2.pid
 
-../../src/runner -I 0 -o 10 --period 2000 --runtime 1000 --deadline 100 --calctime 1000 --sleeptime 1100 &
+../../src/runner -I 0 -o 0 --period 1000 --runtime 100 --deadline 200 --sleeptime 0 &
 PID3=$!
-echo $PID3 > ./deadlinerunner.pid
+echo $PID3 > ./deadlinerunner3.pid
 
-../../src/runner -I 0 -o 10 --cpu-iterations 10000000000 --sleeptime 0 &
+../../src/runner -I 0 -o 0 --cpu-iterations 100000000000 --sleeptime 0 &
 PID4=$!
+echo $PID4 > ./sched_other_runner1.pid
 
 EVENTS='sched:sched_switch,sched:sched_wakeup'
 perf record -C 0 -e $EVENTS &
 PID5=$!
 
 # execute test for N seconds
-sleep 30
+sleep 120
 
 # kill everything
 kill -15 $PID1
-kill -15 $PID2
-kill -15 $PID3
-kill -15 $PID4
+#kill -15 $PID2
+#kill -15 $PID3
+#kill -15 $PID4
 sleep 1
 kill -15 $PID5
 
 mkdir results
-sleep 2
+sleep 2 # We need to wait a bit, otherwise perf script will find an empty file
 perf script > ./results/results.txt
-python3 timeparser.py

--- a/analysis/02-3-deadline-tasks/02-3-deadline-tasks.sh
+++ b/analysis/02-3-deadline-tasks/02-3-deadline-tasks.sh
@@ -4,8 +4,7 @@
 # 3 deadline scheduler processes and a busy SCHED_OTHER
 # process
 cd $(dirname $0)
-sh ../configure-cpu-set.sh
-
+sh ../configure-super-exclusive-cpu-set.sh
 
 perf sched record ../../src/runner -I 0 --period 2000 --runtime 150 --deadline 500 --calctime 100 --sleeptime 1900 &
 PID1=$!
@@ -18,15 +17,23 @@ PID2=$!
 PID3=$!
 
 # sched other. With this config it will attempt to calculate forever
-../../src/runner -I 0 --cpu-iterations 1000000000000 --sleeptime 0 &
+../../src/runner -I 0 --cpu-iterations 10000000000 --sleeptime 0 &
 PID4=$!
-
 
 # execute test for N seconds
 sleep 60
+
+EVENTS='sched:sched_switch,sched:sched_wakeup'
+perf record -C 3 -e $EVENTS &
+PID5=$!
 
 # kill everything
 kill -9 $PID1
 kill -9 $PID2
 kill -9 $PID3
 kill -9 $PID4
+kill -9 $PID5
+
+mkdir results
+sleep 2
+echo $(PID4) > ./deadlinerunner.pid

--- a/analysis/02-3-deadline-tasks/02-3-deadline-tasks.sh
+++ b/analysis/02-3-deadline-tasks/02-3-deadline-tasks.sh
@@ -7,17 +7,17 @@ cd $(dirname $0)
 sh ./configure-cpu-set.sh
 echo $$ > /dev/cpuset/cpu0/tasks
 
-../../src/runner -I 0 -o 1 --period 2000 --runtime 100 --deadline 900 --calctime 100 --sleeptime 1900 &
+../../src/runner -I 0 -o 10 --period 1000 --runtime 100 --deadline 900 --calctime 100 --sleeptime 1900 &
 PID1=$!
 
-../../src/runner -I 0 -o 1 --period 2000 --runtime 150 --deadline 500 --calctime 100 --sleeptime 1900 &
+../../src/runner -I 0 -o 10 --period 1000 --runtime 150 --deadline 500 --calctime 100 --sleeptime 1900 &
 PID2=$!
 
-../../src/runner -I 0 -o 1 --period 2000 --runtime 150 --deadline 500 --calctime 100 --sleeptime 1900 &
+../../src/runner -I 0 -o 10 --period 2000 --runtime 1000 --deadline 100 --calctime 1000 --sleeptime 1100 &
 PID3=$!
 echo $PID3 > ./deadlinerunner.pid
 
-../../src/runner -I 0 -o 1 --cpu-iterations 10000000000 --sleeptime 0 &
+../../src/runner -I 0 -o 10 --cpu-iterations 10000000000 --sleeptime 0 &
 PID4=$!
 
 EVENTS='sched:sched_switch,sched:sched_wakeup'

--- a/analysis/02-3-deadline-tasks/Makefile
+++ b/analysis/02-3-deadline-tasks/Makefile
@@ -5,4 +5,4 @@ rerun:
 	/bin/sh 01-one-sched-other-one-second-rerun.sh
 
 clean:
-	rm -f perf.data perf.data.old ./results/results.txt
+	rm -f perf.data perf.data.old ./results/* deadlinerunner.pid

--- a/analysis/02-3-deadline-tasks/Makefile
+++ b/analysis/02-3-deadline-tasks/Makefile
@@ -1,0 +1,8 @@
+all:
+	/bin/sh 02-3-deadline-tasks.sh
+
+rerun:
+	/bin/sh 01-one-sched-other-one-second-rerun.sh
+
+clean:
+	rm -f perf.data perf.data.old ./results/results.txt

--- a/analysis/02-3-deadline-tasks/configure-cpu-set.sh
+++ b/analysis/02-3-deadline-tasks/configure-cpu-set.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/bash
+
+mkdir /dev/cpuset
+mount -t cgroup -o cpuset cpuset /dev/cpuset
+cd /dev/cpuset
+mkdir cpu0
+echo 0 > cpu0/cpuset.cpus
+echo 0 > cpu0/cpuset.mems
+echo 1 > cpuset.cpu_exclusive
+echo 0 > cpuset.sched_load_balance
+echo 1 > cpu0/cpuset.cpu_exclusive
+echo 1 > cpu0/cpuset.mem_exclusive

--- a/analysis/02-3-deadline-tasks/plotter.py
+++ b/analysis/02-3-deadline-tasks/plotter.py
@@ -15,16 +15,15 @@ for line in reader:
     runtimes.append(int(line[3]))
     start_time_current += int(line[2])
 
-bars = [(start, runtime) for start, runtime in zip(start_times, runtimes)]
-print(bars)
+bars = [(start, runtime) for start, runtime in zip(start_times[:100], runtimes[:100])]
 
 ax.broken_barh(bars, (10, 9), facecolors='tab:blue')
 ax.set_ylim(5, 25)
 ax.set_xlabel('seconds since start')
 ax.set_yticks([15, 25])
+ax.set_xticks([i for i in range(0, bars[-1][1], int(1e6))])
 
 ax.grid(True)
-
 
 f.close()
 plt.show()

--- a/analysis/02-3-deadline-tasks/plotter.py
+++ b/analysis/02-3-deadline-tasks/plotter.py
@@ -1,0 +1,30 @@
+import matplotlib.pyplot as plt
+import csv
+
+fig, ax = plt.subplots()
+
+f = open('./results/results.csv', 'r')
+reader = csv.reader(f)
+
+start_times = []
+runtimes = []
+
+start_time_current = 0
+for line in reader:
+    start_times.append(start_time_current)
+    runtimes.append(int(line[3]))
+    start_time_current += int(line[2])
+
+bars = [(start, runtime) for start, runtime in zip(start_times, runtimes)]
+print(bars)
+
+ax.broken_barh(bars, (10, 9), facecolors='tab:blue')
+ax.set_ylim(5, 25)
+ax.set_xlabel('seconds since start')
+ax.set_yticks([15, 25])
+
+ax.grid(True)
+
+
+f.close()
+plt.show()

--- a/analysis/02-3-deadline-tasks/timeparser.py
+++ b/analysis/02-3-deadline-tasks/timeparser.py
@@ -80,14 +80,15 @@ def main():
     with open("./deadlinerunner.pid", "r") as pidfile:
         pid = str(pidfile.readline()).rstrip('\n')
 
-    pid = " " + pid + " "
+    pid_alone = " " + pid + " "
+    pid_from_other_proc = "pid=" + pid
     print(pid)
 
     switch_in  = []
     switch_out = []
 
     for line in f:
-        if pid in line:
+        if pid_alone in line or pid_from_other_proc in line:
             print(line)
             line_parser(line, switch_in, switch_out)
     f.close()

--- a/analysis/02-3-deadline-tasks/timeparser.py
+++ b/analysis/02-3-deadline-tasks/timeparser.py
@@ -1,5 +1,6 @@
 import re
 import csv
+import sys
 
 first_time = True
 
@@ -79,8 +80,10 @@ def storer(switch_in, switch_out):
 def main():
     f = open("./results/results.txt")
     pid = 0
-    with open("./deadlinerunner.pid", "r") as pidfile:
-        pid = str(pidfile.readline()).rstrip('\n')
+    
+    pidfile = sys.argv[1]
+    with open(pidfile, "r") as p:
+        pid = str(p.readline()).rstrip('\n')
 
     switch_in  = []
     switch_out = []

--- a/analysis/02-3-deadline-tasks/timeparser.py
+++ b/analysis/02-3-deadline-tasks/timeparser.py
@@ -1,0 +1,95 @@
+import re
+import csv
+
+first_time = True
+
+def grep_time(line):
+    match = re.search(r'(\d+\.\d+)', line)
+    f = float(match.group(0))
+    i = int(f * 1000 * 1000)
+    return i
+
+
+def switches_from_runner(line):
+    match = re.search(r'=runner.*?==>', line)
+
+    if match is None:
+        return False
+    else:
+        return True
+
+
+def switches_to_runner(line):
+    match = re.search(r'==>.*?runner', line)
+
+    if match is None:
+        return False
+    else:
+        return True
+
+
+def line_parser(line, switch_in, switch_out):
+    global first_time
+
+    if "sched_switch" in line:
+        if switches_to_runner(line):
+            switch_in.append(grep_time(line))
+        elif switches_from_runner(line):
+            switch_out.append(grep_time(line))
+
+        # Make sure the first match is a switch_in
+        if first_time:
+            if len(switch_out) > len(switch_in):
+                switch_out.pop()
+            first_time = False
+
+
+def storer(switch_in, switch_out):
+    f = open('./results/results.csv', 'wt')
+    first_time = True
+    t_in_prev = 0
+    print("Times in microseconds.")
+    print("{:>5} {:>20} {:>30} {:>20}"
+            .format("Nr.", "switch_in_timestamp", "time_since_list_switch_in",
+                "runtime"))
+    writer = csv.writer(f, delimiter=',')
+
+    iter_list = zip(range(1, len(switch_in) + 1), switch_in, switch_out)
+    for nr, t_in, t_out in iter_list:
+        since_last = t_in - t_in_prev
+        runtime = t_out - t_in
+
+        if first_time:
+            since_last = 0
+            first_time = False
+
+        line_new = '{:>5} {:>20} {:>30} {:>20}'.format(nr, t_in, since_last, runtime)
+        print(line_new)
+        t_in_prev = t_in
+        if nr % 5 == 0:
+            print("")
+        writer.writerow([nr, t_in, since_last, runtime])
+
+    f.close()
+
+
+
+def main():
+    f = open("./results/results.txt")
+    pid = 0
+    with open("./deadlinerunner.pid", "r") as pidfile:
+        pid = str(pidfile.readline())
+
+    switch_in  = []
+    switch_out = []
+
+    for line in f:
+        if pid in line:
+            line_parser(line, switch_in, switch_out)
+    f.close()
+
+    storer(switch_in, switch_out)
+
+
+if __name__ == '__main__':
+    main()

--- a/analysis/02-3-deadline-tasks/timeparser.py
+++ b/analysis/02-3-deadline-tasks/timeparser.py
@@ -78,13 +78,17 @@ def main():
     f = open("./results/results.txt")
     pid = 0
     with open("./deadlinerunner.pid", "r") as pidfile:
-        pid = str(pidfile.readline())
+        pid = str(pidfile.readline()).rstrip('\n')
+
+    pid = " " + pid + " "
+    print(pid)
 
     switch_in  = []
     switch_out = []
 
     for line in f:
         if pid in line:
+            print(line)
             line_parser(line, switch_in, switch_out)
     f.close()
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,7 +1,7 @@
 # disable optimization, just to make sure the dead code
 # is not elliminated, furthermore we need debugging symbols
 # later for perf analysis
-CFLAGS  = -g -Wall -O0
+CFLAGS  = -g -Wall -Wextra -O0
 
 TARGET = runner
 
@@ -9,6 +9,9 @@ all: $(TARGET)
 
 $(TARGET): $(TARGET).c
 	$(CC) $(CFLAGS) -o $(TARGET) $(TARGET).c
+
+debug: $(TARGET).c
+	$(CC) -D DEBUG $(CFLAGS) -o $(TARGET) $(TARGET).c
 
 clean:
 	$(RM) $(TARGET)

--- a/src/runner.c
+++ b/src/runner.c
@@ -315,8 +315,9 @@ void xsleep(struct config *cfg)
 
 int main(int argc, char *argv[])
 {
-	unsigned i;
+	unsigned i, calculated;
 	bool run = true;
+	(void)calculated;
 
 	struct sched_attr attr = {
 		.size = sizeof(struct sched_attr),
@@ -351,8 +352,9 @@ int main(int argc, char *argv[])
 	}
 
 	for (i = 0; run; i++) {
+		calculated = busy_cycles(cfg.cpu_iterations);
 #ifdef DEBUG
-		printf("Calculated for %u us.\n", busy_cycles(cfg.cpu_iterations));
+		printf("Calculated for %u us.\n", calculated);
 #endif
 		xsleep(&cfg);
 

--- a/src/runner.c
+++ b/src/runner.c
@@ -272,7 +272,7 @@ void oak_cpu(struct config *cfg)
 	long long reg = 0, i;
 
 	puts("entering oak loop");
-	for (i = 0; i < OAKING_LOOPS; i++) {
+	for (i = 0; i < cfg->oak_runs; i++) {
 		calctime_now = 0, reg = 0;
 		reg = calctime_goal * 1000;
 


### PR DESCRIPTION
In this version, I:

- use only 1 cpuset to measure deadlines, since it's expectable that "noise" by other programs won't matter thanks to the deadline scheduler. We want noise anyways, to see if deadline works as intended
- created an own version for parsing the perf logfile (as we have several runners now we need to watch for the PID)

This is WIP. There's still a bug in the timeparser and if we are going to use several CPUsets we need some finetuning, because there are mechanisms like load balancing etc.
It's always troublesome that the main parent set will aways host freshly spawned processes.

update:
This is now ready to be merged.
I have not yet taken care of building perf manually. Will be one of the next steps.